### PR TITLE
Handle None TypeError on utc_offset

### DIFF
--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -166,7 +166,10 @@ def getCCodeLangAndOffset():
     nfo = ipapi.location()
     lang = nfo['languages'].split(',')[0]
     geo = nfo['country']
-    tz = str(round(int(nfo['utc_offset']) / 100 * 60))
+    if nfo['utc_offset'] == None:
+        tz = str(0)
+    else:
+        tz = str(round(int(nfo['utc_offset']) / 100 * 60))
     return(lang, geo, tz)
 
 def getGoogleTrends(numberOfwords: int) -> list:


### PR DESCRIPTION
If you are running on a system (like Linux) using UTC as the local timezone then ipapi may return None as the utc_offset.  This results in a TypeError when calculating the utc_offset value for later use.  This fixes it by checking to see if it is None in advance of doing the math and setting to 0 if it is.

I had it echo the contents of the nfo array so you can see what I mean.
```
███╗   ███╗███████╗    ███████╗ █████╗ ██████╗ ███╗   ███╗███████╗██████╗
████╗ ████║██╔════╝    ██╔════╝██╔══██╗██╔══██╗████╗ ████║██╔════╝██╔══██╗
██╔████╔██║███████╗    █████╗  ███████║██████╔╝██╔████╔██║█████╗  ██████╔╝
██║╚██╔╝██║╚════██║    ██╔══╝  ██╔══██║██╔══██╗██║╚██╔╝██║██╔══╝  ██╔══██╗
██║ ╚═╝ ██║███████║    ██║     ██║  ██║██║  ██║██║ ╚═╝ ██║███████╗██║  ██║
╚═╝     ╚═╝╚══════╝    ╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝
        by Charles Bel (@charlesbel)               version 1.1

{'ip': '[removed]', 'version': 'IPv6', 'city': 'Saint-Victor', 'region': 'Quebec', 'region_code': None, 'country': 'CA', 'country_name': 'Canada', 'country_code': 'CA', 'country_code_iso3': 'CAN', 'country_capital': 'Ottawa', 'country_tld': '.ca', 'continent_code': 'NA', 'in_eu': False, 'postal': None, 'latitude': None, 'longitude': None, 'timezone': None, 'utc_offset': None, 'country_calling_code': '+1', 'currency': 'CAD', 'currency_name': 'Dollar', 'languages': 'en-CA,fr-CA,iu', 'country_area': 9984670.0, 'country_population': 37058856.0, 'asn': '[removed]', 'org': '[removed]'}
Traceback (most recent call last):
  File "./ms_rewards_farmer.py", line 728, in <module>
    LANG, GEO, TZ = getCCodeLangAndOffset()
  File "./ms_rewards_farmer.py", line 170, in getCCodeLangAndOffset
    tz = str(round(int(nfo['utc_offset']) / 100 * 60))
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

I'm just pre-checking the value to make sure to handle None appropriately by just setting tz to 0.  My local system timezone is set to UTC on this box and so would have a 0 offset.

ip, asn, and org was removed for privacy.