### PR TITLE
Mobile search fix, less CPU usage, & verbose notifs 

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,9 +15,9 @@ POINTS_COUNTER = 0
 
 
 def main():
-    setupLogging()
     args = argumentParser()
     notifier = Notifier(args)
+    setupLogging(args.verbosenotifs, notifier)
     loadedAccounts = setupAccounts()
     for currentAccount in loadedAccounts:
         try:
@@ -26,7 +26,10 @@ def main():
             logging.exception(f"{e.__class__.__name__}: {e}")
 
 
-def setupLogging():
+def setupLogging(verbose_notifs, notifier):
+    ColoredFormatter.verbose_notifs = verbose_notifs
+    ColoredFormatter.notifier = notifier
+
     format = "%(asctime)s [%(levelname)s] %(message)s"
     terminalHandler = logging.StreamHandler(sys.stdout)
     terminalHandler.setFormatter(ColoredFormatter(format))
@@ -82,6 +85,9 @@ def argumentParser() -> argparse.Namespace:
         type=str,
         default=None,
         help="Optional: Discord Webhook URL (ex: https://discord.com/api/webhooks/123456789/ABCdefGhIjKlmNoPQRsTUVwxyZ)",
+    )
+    parser.add_argument(
+        "-vn", "--verbosenotifs", action="store_true", help="Optional: Send all the logs to discord/telegram"
     )
     return parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -151,6 +151,15 @@ def executeBot(currentAccount, notifier: Notifier, args: argparse.Namespace):
                 remainingSearches
             )
 
+        if remainingSearchesM != 0:
+            desktopBrowser.closeBrowser()
+            with Browser(
+                mobile=True, account=currentAccount, args=args
+            ) as mobileBrowser:
+                accountPointsCounter = Login(mobileBrowser).login()
+                accountPointsCounter = Searches(mobileBrowser).bingSearches(
+                    remainingSearchesM
+                )
         desktopBrowser.webdriver.quit()
 
         logging.info(

--- a/main.py
+++ b/main.py
@@ -87,7 +87,10 @@ def argumentParser() -> argparse.Namespace:
         help="Optional: Discord Webhook URL (ex: https://discord.com/api/webhooks/123456789/ABCdefGhIjKlmNoPQRsTUVwxyZ)",
     )
     parser.add_argument(
-        "-vn", "--verbosenotifs", action="store_true", help="Optional: Send all the logs to discord/telegram"
+        "-vn",
+        "--verbosenotifs",
+        action="store_true",
+        help="Optional: Send all the logs to discord/telegram",
     )
     return parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -151,15 +151,7 @@ def executeBot(currentAccount, notifier: Notifier, args: argparse.Namespace):
                 remainingSearches
             )
 
-        if remainingSearchesM != 0:
-            desktopBrowser.closeBrowser()
-            with Browser(
-                mobile=True, account=currentAccount, args=args
-            ) as mobileBrowser:
-                accountPointsCounter = Login(mobileBrowser).login()
-                accountPointsCounter = Searches(mobileBrowser).bingSearches(
-                    remainingSearchesM
-                )
+        desktopBrowser.webdriver.quit()
 
         logging.info(
             f"[POINTS] You have earned {desktopBrowser.utils.formatNumber(accountPointsCounter - startingPoints)} points today !"

--- a/src/loggingColoredFormatter.py
+++ b/src/loggingColoredFormatter.py
@@ -2,6 +2,9 @@ import logging
 
 
 class ColoredFormatter(logging.Formatter):
+    verbose_notifs = False
+    notifier = str()
+
     grey = "\x1b[38;21m"
     blue = "\x1b[38;5;39m"
     yellow = "\x1b[38;5;226m"
@@ -22,5 +25,9 @@ class ColoredFormatter(logging.Formatter):
 
     def format(self, record):
         logFmt = self.FORMATS.get(record.levelno)
+
+        if self.verbose_notifs:
+            self.notifier.send(f"[{logging.getLevelName(record.levelno)}] {record.msg}")
+
         formatter = logging.Formatter(logFmt)
         return formatter.format(record)

--- a/src/searches.py
+++ b/src/searches.py
@@ -75,9 +75,11 @@ class Searches:
         return pointsCounter
 
     def bingSearch(self, word: str):
+        i = 0
+        self.webdriver.get("https://bing.com")
+
         while True:
             try:
-                self.webdriver.get("https://bing.com")
                 self.browser.utils.waitUntilClickable(By.ID, "sb_form_q")
                 searchbar = self.webdriver.find_element(By.ID, "sb_form_q")
                 searchbar.send_keys(word)
@@ -85,6 +87,11 @@ class Searches:
                 time.sleep(random.randint(10, 15))
                 return self.browser.utils.getBingAccountPoints()
             except TimeoutException:
+                if i == 5:
+                    logging.error("[BING] " + "Cancelling mobile searches due to too many retries.")
+                    return self.browser.utils.getBingAccountPoints()
+
                 logging.error("[BING] " + "Timeout, retrying in 5 seconds...")
                 time.sleep(5)
+                i += 1
                 continue

--- a/src/searches.py
+++ b/src/searches.py
@@ -55,6 +55,8 @@ class Searches:
 
         i = 0
         search_terms = self.getGoogleTrends(numberOfSearches)
+        self.webdriver.get("https://bing.com")
+
         for word in search_terms:
             i += 1
             logging.info("[BING] " + f"{i}/{numberOfSearches}")
@@ -76,19 +78,22 @@ class Searches:
 
     def bingSearch(self, word: str):
         i = 0
-        self.webdriver.get("https://bing.com")
 
         while True:
             try:
                 self.browser.utils.waitUntilClickable(By.ID, "sb_form_q")
                 searchbar = self.webdriver.find_element(By.ID, "sb_form_q")
+                searchbar.clear()
                 searchbar.send_keys(word)
                 searchbar.submit()
                 time.sleep(random.randint(10, 15))
                 return self.browser.utils.getBingAccountPoints()
             except TimeoutException:
                 if i == 5:
-                    logging.error("[BING] " + "Cancelling mobile searches due to too many retries.")
+                    logging.error(
+                        "[BING] "
+                        + "Cancelling mobile searches due to too many retries."
+                    )
                     return self.browser.utils.getBingAccountPoints()
 
                 logging.error("[BING] " + "Timeout, retrying in 5 seconds...")


### PR DESCRIPTION
You can use -vn or -verbosenotifs to turn on sending all logs to which notification service you use. (discord, telegram)

Less CPU fix currently does not work

For #273, #277, and #298 

You may need to delete your sessions folder if timeout exceptions still occur