### PR TITLE
Add setuptools to requirements.txt for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ selenium
 ipapi
 undetected-chromedriver
 selenium-wire
+setuptools


### PR DESCRIPTION
This pull request addresses the removal of setuptools as a default library in Python 3.12.

Changes:
- Added setuptools to requirements.txt

Fixes: [#375](https://github.com/charlesbel/Microsoft-Rewards-Farmer/issues/375)