### PR TITLE
fix IndexError in utils.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ def setupAccounts() -> dict:
 
 def executeBot(currentAccount, notifier: Notifier, args: argparse.Namespace):
     logging.info(
-        f'********************{ currentAccount.get("username", "") }********************'
+        f'********************{currentAccount.get("username", "")}********************'
     )
     with Browser(mobile=False, account=currentAccount, args=args) as desktopBrowser:
         accountPointsCounter = Login(desktopBrowser).login()

--- a/src/utils.py
+++ b/src/utils.py
@@ -202,18 +202,21 @@ class Utils:
         dashboard = self.getDashboardData()
         searchPoints = 1
         counters = dashboard["userStatus"]["counters"]
-        if "PCSearch" not in counters:
+
+        if "pcSearch" not in counters:
             return 0, 0
-        progressDesktop = (
-            counters["PCSearch"][0]["pointProgress"]
-            + counters["PCSearch"][1]["pointProgress"]
-        )
-        targetDesktop = (
-            counters["PCSearch"][0]["pointProgressMax"]
-            + counters["PCSearch"][1]["pointProgressMax"]
-        )
+        progressDesktop = 0
+
+        for item in counters['pcSearch']:
+            progressDesktop += item.get('pointProgress', 0)
+
+        targetDesktop = 0
+
+        for item in counters['pcSearch']:
+            targetDesktop += item.get('pointProgressMax', 0)
+
         if targetDesktop in [33, 102]:
-            # Level 1 or 2 EU
+            # Level 1 or 2 EU/South America
             searchPoints = 3
         elif targetDesktop == 55 or targetDesktop >= 170:
             # Level 1 or 2 US

--- a/src/utils.py
+++ b/src/utils.py
@@ -202,15 +202,15 @@ class Utils:
         dashboard = self.getDashboardData()
         searchPoints = 1
         counters = dashboard["userStatus"]["counters"]
-        if "pcSearch" not in counters:
+        if "PCSearch" not in counters:
             return 0, 0
         progressDesktop = (
-            counters["pcSearch"][0]["pointProgress"]
-            + counters["pcSearch"][1]["pointProgress"]
+            counters["PCSearch"][0]["pointProgress"]
+            + counters["PCSearch"][1]["pointProgress"]
         )
         targetDesktop = (
-            counters["pcSearch"][0]["pointProgressMax"]
-            + counters["pcSearch"][1]["pointProgressMax"]
+            counters["PCSearch"][0]["pointProgressMax"]
+            + counters["PCSearch"][1]["pointProgressMax"]
         )
         if targetDesktop in [33, 102]:
             # Level 1 or 2 EU


### PR DESCRIPTION
This should fix the IndexError in utils.py related to the dictionary 'counters', which was happening because neither the `counters["pcSearch"][1]["pointProgress"]` nor the `counters["pcSearch"][1]["pointProgress"]` existed


Fixes: https://github.com/charlesbel/Microsoft-Rewards-Farmer/issues/401