### PR TITLE
Downgrade blinker for compatibility with selenium-wire

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ selenium
 ipapi
 undetected-chromedriver
 selenium-wire
+blinker<1.8.0

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+aecd6c0806055dab1d769ba8ccb0aa2ebee3f1db

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,0 @@
-aecd6c0806055dab1d769ba8ccb0aa2ebee3f1db


### PR DESCRIPTION
selenium-wire is unmaintained and breaks with blinker>=1.8.0